### PR TITLE
Attach to stderr in toBuffer

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -159,11 +159,14 @@ module.exports = function (proto) {
       throw new Error('gm().toBuffer() expects a callback.');
     }
 
-    return this.stream(format, function (err, stdout) {
+    return this.stream(format, function (err, stdout, stderr) {
       if (err) return callback(err);
+      stderr.on('data', function(data) {
+        debug('stderr ' + data.toString('utf-8'));
+      });
 
       streamToUnemptyBuffer(stdout, callback);
-    })
+    });
   }
 
   /**


### PR DESCRIPTION
In cases where stderr streams a lot of diagnostic, the process
would block waiting for stderr buffer flush.

We saw this occur with a PDF (ghostscript logging warnings).
